### PR TITLE
Missing super dealloc call

### DIFF
--- a/RNTimer/RNTimer.m
+++ b/RNTimer/RNTimer.m
@@ -66,6 +66,7 @@
 
 - (void)dealloc {
   [self invalidate];
+  [super dealloc];
 }
 
 - (void)fire {


### PR DESCRIPTION
My code analyzer spilled out a warning about a missing `dealloc` call to `super`. What do you think is it really missing or am I wrong here? 
